### PR TITLE
DR-304 Gitleaks new rules

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,29 +3,17 @@
 [extend]
 useDefault = true # SEE: https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
 
+[allowlist]
+description = "allow ="
+Regexes = '''========================================='''
+
 [[rules]]
 description = "IPv4"
 id = "ipv4"
 regex = '''[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'''
 
-# commented out pending further investigation
-# [[rules]]
-# id = "password"
-# description = "Passwords "
-# regex = '''(?i)(?:secret|key|signature|password|pwd|pass|token)(?:\w|\s*?)(?:=){1}(?:\s{0,10})[\"'`](.*?)[\"'`]'''
-# [[rules.Entropies]]
-#   Min = "3"
-#   Max = "7"
-#   Group = "1"
-
-# [[rules]]
-# id = "AWS account"
-# description = "AWS account number  - 12 digits"
-# regex = '''[0-9]{12}'''
-
-
 [[rules]]
-description = "DynamoDB Endpoint"
+description = "DynamoDB Endpoints"
 id = "dynamodb"
 regex = '''dynamodb\.[a-z]{2}[a-z-]*[1,2,3]\.amazonaws\.com'''
 
@@ -40,16 +28,14 @@ id = "arns3"
 regex = '''arn:aws:s3:::(.*)'''
 
 [[rules]]
-description = "ECR Endpoint"
+description = "ECR Endpoints"
 id = "ecr"
 regex = '''[0-9]{12}\.dkr\.ecr\.[a-z-]*-[1,2,3]\.amazonaws\.com'''
 
-
 [[rules]]
-description = "Elastic Search Endpoint"
-id = "esendpoint"
+description = "Elastic Search Endpoints"
+id = "esendpoints"
 regex = '''(.*)[a-z-]*[1,2,3]\.es\.amazonaws\.com'''
-
 
 [[rules]]
 description = "Standard Certificate"
@@ -60,3 +46,18 @@ regex = '''-----BEGIN(\s)CERTIFICATE-----\n'''
 description = "Private Keys"
 id = "privatekeys"
 regex = '''\s*(\bBEGIN\b).*(PRIVATE KEY\b)\s*'''
+
+[[rules]]
+description = "AWS Secret Access Key"
+id = "secretaccesskey"
+regex = '''(AWS|aws|Aws)?_?(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)?\s*(:|=>|=)\s*[A-Za-z0-9/\+=]{40}\n'''
+
+[[rules]]
+id = "genericawsacno"
+description = "Generic 12 digit AWS acccount number"
+regex = '''\b\d{12}\b'''
+
+[[rules]]
+id = "awsaccountid"
+description = "AWS Account ID"
+regex = '''(AWS|aws|Aws)?_?(ACCOUNT|account|Account)_?(ID|id|Id)?\s*(:|=>|=)\s*[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}'''


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

There was a requirement to create additional custom gitleaks rules to detect AWS secret keys and AWS account numbers / ID. 

New rules detects the following in the scan-secrets pipeline workflow:

- Detects AWS Secret Access Keys
- Detects Generic 12 digit AWS account numbers
- Detects AWS Account ID in the format of 'aws_account_id'


## Context

This change is required in order to ensure that gitleaks detects and flags as much sensitive information as we want it to and the code base is secure.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
