### PR TITLE
DR 30 add missing read-only policy for IAM

### DIFF
--- a/infrastructure/stacks/github-runner/role.tf
+++ b/infrastructure/stacks/github-runner/role.tf
@@ -11,12 +11,18 @@ resource "aws_iam_role_policy_attachment" "attach_power_user" {
   role       = aws_iam_role.github_runner_role.name
   policy_arn = data.aws_iam_policy.power_user_policy.arn
 }
-resource "aws_iam_policy" "ro_policy_1" {
+resource "aws_iam_policy" "ro_policy_iam" {
   name        = "uec-ro-iam-services"
   description = "Read-only policies for key iam permissions required by github runner"
 
   policy = file("uec-ro-iam-services.json")
 }
+
+resource "aws_iam_role_policy_attachment" "attach_ro_iam" {
+  role       = aws_iam_role.github_runner_role.name
+  policy_arn = aws_iam_policy.ro_policy_iam.arn
+}
+
 
 resource "aws_iam_role" "github_runner_role" {
   name               = "uec-github-runner"

--- a/infrastructure/stacks/github-runner/role.tf
+++ b/infrastructure/stacks/github-runner/role.tf
@@ -11,6 +11,12 @@ resource "aws_iam_role_policy_attachment" "attach_power_user" {
   role       = aws_iam_role.github_runner_role.name
   policy_arn = data.aws_iam_policy.power_user_policy.arn
 }
+resource "aws_iam_policy" "ro_policy_1" {
+  name        = "uec-ro-iam-services"
+  description = "Read-only policies for key iam permissions required by github runner"
+
+  policy = file("uec-ro-iam-services.json")
+}
 
 resource "aws_iam_role" "github_runner_role" {
   name               = "uec-github-runner"

--- a/infrastructure/stacks/github-runner/uec-ro-iam-services.json
+++ b/infrastructure/stacks/github-runner/uec-ro-iam-services.json
@@ -1,0 +1,17 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:GenerateCredentialReport",
+                "iam:GenerateServiceLastAccessedDetails",
+                "iam:Get*",
+                "iam:List*",
+                "iam:SimulateCustomPolicy",
+                "iam:SimulatePrincipalPolicy"
+            ],
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Git hub runner role needs some limited ro permissions to get iam aliases and policies
New RO policy added to the github-runner stack called as part of bootstrapper script
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
