### PR TITLE
DR-320 Git standard config

### DIFF
--- a/scripts/git/git-config-set-up.sh
+++ b/scripts/git/git-config-set-up.sh
@@ -7,3 +7,16 @@ chmod +x .git/hooks/pre-commit
 rm -f .git/hooks/commit-msg
 cp scripts/git/commit-msg .git/hooks/commit-msg
 chmod +x .git/hooks/commit-msg
+
+git config branch.autosetupmerge false    
+git config branch.autosetuprebase always    
+git config commit.gpgsign true    
+git config core.autocrlf input    
+git config core.filemode true    
+git config core.hidedotfiles false    
+git config core.ignorecase false    
+git config pull.rebase true    
+git config push.default current    
+git config push.followTags true    
+git config rebase.autoStash true    
+git config remote.origin.prune true git 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

There was a requirement to use a standard git config amongst the dev team as best practice.

The following additional configs were identified and agreed to use:

git config branch.autosetupmerge false    
git config branch.autosetuprebase always    
git config commit.gpgsign true    
git config core.autocrlf input    
git config core.filemode true    
git config core.hidedotfiles false    
git config core.ignorecase false    
git config pull.rebase true    
git config push.default current    
git config push.followTags true    
git config rebase.autoStash true    
git config remote.origin.prune true git 

The specified configs are added to the existing shell script: scripts/git/git-config-set-up.sh

## Context

This change is required in order to ensure the dev team has a standardised git config.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
